### PR TITLE
Informative message if no id.vars

### DIFF
--- a/R/melt.r
+++ b/R/melt.r
@@ -234,7 +234,11 @@ melt_check <- function(data, id.vars, measure.vars) {
     discrete <- sapply(data, is.discrete)
     id.vars <- varnames[discrete]
     measure.vars <- varnames[!discrete]
-    message("Using ", paste(id.vars, collapse = ", "), " as id variables")
+    if (length(id.vars) != 0) {
+      message("Using ", paste(id.vars, collapse = ", "), " as id variables")
+    } else {
+      message("Using all variables as measure variables")  
+    }
   } else if (missing(id.vars)) {
     id.vars <- setdiff(varnames, measure.vars)
   } else if (missing(measure.vars)) {


### PR DESCRIPTION
Sometimes there is a need to melt data "as is", i.e. with no arguments provided:

``` r
df <- data.frame(a=1:3, b=4:6)
melt(df)
```

The output is 

``` r
Using  as id variables
  variable value
1        a     1
2        a     2
3        a     3
4        b     4
5        b     5
6        b     6
```

The message is not very informative and may be misleading. A small "if" handles this case, changing the message. 
