### PR TITLE
Handle 'no measure.variables' case; closes #46

### DIFF
--- a/R/melt.r
+++ b/R/melt.r
@@ -117,6 +117,11 @@ melt.data.frame <- function(data, id.vars, measure.vars, variable.name = "variab
   id.ind <- match(vars$id, names(data))
   measure.ind <- match(vars$measure, names(data))
 
+  ## Return early if we have id.ind but no measure.ind
+  if (!length(measure.ind)) {
+    return(data[id.vars])
+  }
+
   ## Get the attributes if common, NULL if not.
   args <- normalize_melt_arguments(data, measure.ind, factorsAsStrings)
   measure.attributes <- args$measure.attributes

--- a/tests/testthat/test-melt.r
+++ b/tests/testthat/test-melt.r
@@ -173,3 +173,13 @@ test_that("factorsAsStrings behaves as expected", {
   expect_identical( class(m$value), "character" )
 
 })
+
+test_that("melt.data.frame behaves when there are no measure variables", {
+
+  df <- data.frame(x='a', y='b', z='c')
+  m <- melt(df)
+  expect_identical(df, m)
+  m <- melt(df, id.vars = "x", measure.vars = NULL)
+  expect_identical(df["x"], m)
+
+})


### PR DESCRIPTION
Should we throw a warning / print a message if this happens? It seems unlikely one would want to `melt` with no 'measure' variables.
