### PR TITLE
corrected argument to `install_github`

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ This work has been generously supported by BD (Becton Dickinson).
 ## Installation
 
 * Get the released version from cran: `install.packages("reshape2")`
-* Get the dev version from github: `devtools::install_github("hadley/reshape2")`
+* Get the dev version from github: `devtools::install_github("hadley/reshape")`


### PR DESCRIPTION
The correct argument to `install_github` here is actually `reshape` rather than `reshape2` (this is a little confusing!):

```
devtools::install_github("hadley/reshape2")
## Installing github repo reshape2/master from hadley
## Downloading master.zip from https://github.com/hadley/reshape2/archive/master.zip
## Error in (function (url, name = NULL, subdir = NULL, config = list(),  : 
## client error: (404) Not Found
```
