### PR TITLE
Allow lists as id variables (#49)

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
 # Version 1.4.0.99
 
-* `melt.data.frame()` now properly sets the OBJECT bit on `value` variable generated if attributes are copied (for example, when multiple POSIXct columns are concatenated to generate the `value` variable) (#50)
+* `melt.data.frame()` can melt `data.frame`s containing `list` elements as `id`
+  columns. (#49)
+
+* `melt.data.frame()` now properly sets the OBJECT bit on `value` variable
+  generated if attributes are copied (for example, when multiple POSIXct
+  columns are concatenated to generate the `value` variable) (#50)
 
 * `melt.data.frame()` no longer errors when `measure.vars` is `NULL` or empty.
   (#46)

--- a/tests/testthat/test-melt.r
+++ b/tests/testthat/test-melt.r
@@ -198,3 +198,19 @@ test_that("melt.data.frame preserves OBJECT bit on e.g. POSIXct", {
   t.long <- melt(t.wide, measure.vars=c("t1", "t2", "t3"), value.name="time")
   expect_true(object_bit_set(t.long$time))
 })
+
+test_that("melt.data.frame allows for lists in the set of id variables", {
+  df <- data.frame(x = 1:5)
+  df$y <- list(
+    data.frame(),
+    new.env(),
+    as.name("foo"),
+    1,
+    as.POSIXct(Sys.Date())
+  )
+  df$za <- letters[1:5]
+  df$zb <- letters[6:10]
+  df$zc <- letters[11:15]
+  result <- melt(df, id=1:2)
+  expect_identical(result$y[1:5], df$y)
+})


### PR DESCRIPTION
This performs a shallow copy of lists when melting them as id variables.
