### PR TITLE
Added error checking to melt_check to ensure unique measure.vars

### DIFF
--- a/R/melt.r
+++ b/R/melt.r
@@ -275,5 +275,12 @@ melt_check <- function(data, id.vars, measure.vars, variable.name, value.name) {
   if (!is.string(value.name))
     stop("'value.name' should be a string", call. = FALSE)
 
+  # Ensure that measure.vars are unique
+  if (any(duplicated(measure.vars))) {
+      message("Measure variables are not unique - automatically corrected.")
+      measure.vars <- make.names(measure.vars, unique = TRUE)
+  }
+      
+
   list(id = id.vars, measure = measure.vars)
 }


### PR DESCRIPTION
Got caught by this today - identical measure.vars will silently recycle the first column.

> z <- data.frame(A = letters[1:5], this = 1:5, that = 6:10, this = 11:15, that = 16:20, check.names = FALSE)
> melt(z)
Using A as id variables
   A variable value
1  a     this     1
2  b     this     2
3  c     this     3
4  d     this     4
5  e     this     5
6  a     that     6
7  b     that     7
8  c     that     8
9  d     that     9
10 e     that    10
11 a     this     1
12 b     this     2
13 c     this     3
14 d     this     4
15 e     this     5
16 a     that     6
17 b     that     7
18 c     that     8
19 d     that     9
20 e     that    10
