### PR TITLE
Handle special attributes

### DIFF
--- a/R/utils.r
+++ b/R/utils.r
@@ -8,12 +8,34 @@ all_identical <- function(xs) {
   TRUE
 }
 
+pluck <- function (x, name) {
+  lapply(x, `[[`, name)
+}
+
+concatenate_names <- function(attributes) {
+  names_attrs <- pluck(attributes, "names")
+  if (all(vapply(names_attrs, is.character, logical(1)))) {
+    do.call("c", names_attrs)
+  } else {
+    NULL
+  }
+}
+
+zap_special_attributes <- function(attributes) {
+  is_not_special <- lapply(attributes, function(x) {
+    !names(x) %in% c("names", "dim", "dimnames")
+  })
+  Map(`[`, attributes, is_not_special)
+}
+
 ## Get the attributes if common, NULL if not.
 normalize_melt_arguments <- function(data, measure.ind, factorsAsStrings) {
-
   measure.attributes <- lapply(measure.ind, function(i) {
     attributes(data[[i]])
   })
+
+  names <- concatenate_names(measure.attributes)
+  measure.attributes <- zap_special_attributes(measure.attributes)
 
   ## Determine if all measure.attributes are equal
   measure.attrs.equal <- all_identical(measure.attributes)
@@ -24,6 +46,9 @@ normalize_melt_arguments <- function(data, measure.ind, factorsAsStrings) {
     warning("attributes are not identical across measure variables; ",
       "they will be dropped", call. = FALSE)
     measure.attributes <- NULL
+  }
+  if (!is.null(names)) {
+    measure.attributes <- c(measure.attributes, list(names = names))
   }
 
   if (!factorsAsStrings && !measure.attrs.equal) {

--- a/tests/testthat/test-melt.r
+++ b/tests/testthat/test-melt.r
@@ -226,3 +226,26 @@ test_that("melt.data.frame throws when encountering POSIXlt", {
   expect_error(melt(df, measure.vars = c("x", "y")))
 
 })
+
+test_that("melt.data.frame handles named vectors", {
+  # Need to work around data.frame methods as they zap names of atomic
+  # vectors
+  df <- data.frame(col1 = numeric(2))
+  class(df) <- NULL
+  df$col1 <- c(a = 1, b = 2)
+  df$col2 <- c(a = 3, b = 4)
+  class(df) <- "data.frame"
+
+  expect_equal(names(melt(df)$value), c("a", "b", "a", "b"))
+
+  df$col2 <- 3:4
+  expect_equal(names(melt(df)$value), NULL)
+})
+
+test_that("melt.data.frame discards other special attributes", {
+  vec <- 1:2
+  dim(vec) <- 2
+  dimnames(vec) <- list(list("dim", "hop"))
+  df <- data.frame(col1 = vec, col2 = vec)
+  expect_equal(dim(melt(df)$value), NULL)
+})


### PR DESCRIPTION
Currently `melt_dataframe()` creates names attributes that aren't necessarily the same length as the output vector, which makes the print method crash.

```r
# Can only create named column vectors with dplyr
df <- dplyr::data_frame(col1 = c(a = 1, b = 2), col2 = c(a = 10, b = 20))
df <- tidyr::gather(df, "col", "value")

str(df$value)
## [1] "numeric"
##  Named num [1:4] 1 2 10 20
##  - attr(*, "names")= chr [1:2] "a" "b"

print(df$value)
##  *** caught segfault ***
## address 0x400000ae, cause 'memory not mapped'
##
## Traceback:
##  1: print.default(df$value)
##  2: print(df$value)
##
## Possible actions:
## 1: abort (with core dump, if enabled)
## 2: normal R exit
## 3: exit R without saving workspace
## 4: exit R saving workspace
## Selection:
```

This fix concatenates the names of the melted vectors so that the output is appropriately named.

It also takes care of `dim` and `dimnames` because `melt_dataframe()` uses `SET_ATTRIB` wihch bypasses the sanity checks that are normally triggered when modifying those attributes from R, and thus also break various consistency assumptions. These attributes are now simply discarded.