### PR TITLE
Delete reference to "grand_row" and "grand_col"

### DIFF
--- a/R/cast.r
+++ b/R/cast.r
@@ -30,9 +30,9 @@
 #'   identify a single observation for each output cell.  Defaults to length
 #'   (with a message) if needed but not specified.
 #' @param ... further arguments are passed to aggregating function
-#' @param margins vector of variable names (can include "grand\_col" and
-#'   "grand\_row") to compute margins for, or TRUE to compute all margins .
-#'   Any variables that can not be margined over will be silently dropped.
+#' @param margins vector of variable names to compute margins for, or TRUE 
+#'   to compute all margins.  Any variables that can not be margined over 
+#'   will be silently dropped.
 #' @param subset quoted expression used to subset data prior to reshaping,
 #'   e.g. \code{subset = .(variable=="length")}.
 #' @param fill value with which to fill in structural missings, defaults to


### PR DESCRIPTION
Margin variables "grand_row" and "grand_col" have been dropped but still show up in ?cast. 