### PR TITLE
Use explicit imports from plyr

### DIFF
--- a/R/cast.r
+++ b/R/cast.r
@@ -41,7 +41,7 @@
 #' @param value.var name of column which stores values, see
 #'   \code{\link{guess_value}} for default strategies to figure this out.
 #' @seealso \code{\link{melt}},  \url{http://had.co.nz/reshape/}
-#' @import plyr
+#' @importFrom plyr alply amv_dimnames eval.quoted id is.formula llply rbind.fill dvaggregate
 #' @import stringr
 #' @examples
 #' #Air quality example


### PR DESCRIPTION
I think ideally, we could drop the plyr dependency.

We are trying to do away with {plyr}; {reshape2} is one of the downstreams.

In another ideal we'd also do away with {reshape2}, but the dependency footprint thereof is much less manageable, for now.

For now, a step towards removing {plyr} is identifying exactly how {reshape2} uses it.