### PR TITLE
Eschew a_ply in tests

### DIFF
--- a/tests/testthat/test-cast.r
+++ b/tests/testthat/test-cast.r
@@ -97,11 +97,11 @@ test_that("aggregated values computed correctly", {
   count_c <- function(vars) as.table(acast(ffm, as.list(vars), length))
   count_t <- function(vars) table(ffm[vars], useNA = "ifany")
 
-  combs <- matrix(names(ffm)[1:5][t(combn(5, 2))], ncol = 2)
-  a_ply(combs, 1, function(vars) {
+  combs <- data.frame(combn(names(ffm)[1:5], 2L))
+  for (vars in combs) {
     expect_that(count_c(vars), is_equivalent_to(count_t(vars)),
       label = paste(vars, collapse = ", "))
-  })
+  }
 
 })
 


### PR DESCRIPTION
Related to #96 -- a small change to get rid of part of the reliance on {plyr}. It also happens to improve the readability of the test a lot (not that it matters much in the superseded package).